### PR TITLE
fix: use correct variable name when inserting image version to deployment file

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Deploy to stage cluster
         run: |
           echo "Deploying to stage version ${{ env.APP_VERSION }}"
-          sed -i "s|<image>|${{ steps.import-harbor-secrets.outputs.HARBOR_URL }}/tekst/ammo:${{ needs.build-and-publish.outputs.image_version }}|g" k8s/stage/deployment.yml
+          sed -i "s|<image>|${{ steps.import-secrets.outputs.HARBOR_URL }}/tekst/ammo:${{ needs.build-and-publish.outputs.image_version }}|g" k8s/stage/deployment.yml
           sed -i "s/<host_url>/${{ steps.import-secrets.outputs.K8S_HOST_URL }}/g" k8s/stage/ingress.yml
           kubectl config set-cluster stagecl --server=${{ steps.import-secrets.outputs.K8S_STAGE_SERVER }}
           kubectl config set clusters.stagecl.certificate-authority-data ${{ steps.import-secrets.outputs.K8S_STAGE_NB_NO_CA }}


### PR DESCRIPTION
Received InvalidImageName when attempting to deploy to kubernetes because variable import-harbor-secrets doesnt exist.